### PR TITLE
Use Ingress v1 API

### DIFF
--- a/internal/hajimari/ingressapps/apps.go
+++ b/internal/hajimari/ingressapps/apps.go
@@ -7,7 +7,7 @@ import (
 	"github.com/toboshii/hajimari/internal/kube/lists/ingresses"
 	"github.com/toboshii/hajimari/internal/kube/wrappers"
 	"github.com/toboshii/hajimari/internal/log"
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -57,7 +57,7 @@ func (al *List) Get() ([]hajimari.App, error) {
 	return al.items, al.err
 }
 
-func convertIngressesToHajimariApps(ingresses []v1beta1.Ingress) (apps []hajimari.App) {
+func convertIngressesToHajimariApps(ingresses []v1.Ingress) (apps []hajimari.App) {
 	for _, ingress := range ingresses {
 		logger.Debugf("Found ingress with Name '%v' in Namespace '%v'", ingress.Name, ingress.Namespace)
 

--- a/internal/hajimari/ingressapps/filters.go
+++ b/internal/hajimari/ingressapps/filters.go
@@ -4,11 +4,11 @@ import (
 	"github.com/toboshii/hajimari/internal/annotations"
 	"github.com/toboshii/hajimari/internal/config"
 	"github.com/toboshii/hajimari/internal/util/strings"
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 )
 
 // For filtering ingresses having hajimari enable annotation set to true
-func byHajimariEnableAnnotation(ingress v1beta1.Ingress, appConfig config.Config) bool {
+func byHajimariEnableAnnotation(ingress v1.Ingress, appConfig config.Config) bool {
 	if appConfig.DefaultEnable {
 		if val, ok := ingress.Annotations[annotations.HajimariEnableAnnotation]; ok {
 			// Has Hajimari annotation and is enabled
@@ -29,7 +29,7 @@ func byHajimariEnableAnnotation(ingress v1beta1.Ingress, appConfig config.Config
 }
 
 // For filtering ingresses by hajimari instance
-func byHajimariInstanceAnnotation(ingress v1beta1.Ingress, appConfig config.Config) bool {
+func byHajimariInstanceAnnotation(ingress v1.Ingress, appConfig config.Config) bool {
 	if val, ok := ingress.Annotations[annotations.HajimariInstanceAnnotation]; ok {
 		return strings.ContainsBetweenDelimiter(val, appConfig.InstanceName, ",")
 	}

--- a/internal/kube/lists/ingresses/ingresses.go
+++ b/internal/kube/lists/ingresses/ingresses.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/toboshii/hajimari/internal/config"
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -13,15 +13,15 @@ import (
 type List struct {
 	appConfig  config.Config
 	err        error // Used for forwarding errors
-	items      []v1beta1.Ingress
+	items      []v1.Ingress
 	kubeClient kubernetes.Interface
 }
 
 // FilterFunc defined for creating functions that comply with the filtering ingresses
-type FilterFunc func(v1beta1.Ingress, config.Config) bool
+type FilterFunc func(v1.Ingress, config.Config) bool
 
 // NewList creates an List object that you can use to query ingresses
-func NewList(kubeClient kubernetes.Interface, appConfig config.Config, items ...v1beta1.Ingress) *List {
+func NewList(kubeClient kubernetes.Interface, appConfig config.Config, items ...v1.Ingress) *List {
 	return &List{
 		kubeClient: kubeClient,
 		appConfig:  appConfig,
@@ -32,7 +32,7 @@ func NewList(kubeClient kubernetes.Interface, appConfig config.Config, items ...
 // Populate function returns a list of ingresses
 func (il *List) Populate(namespaces ...string) *List {
 	for _, namespace := range namespaces {
-		ingresses, err := il.kubeClient.ExtensionsV1beta1().Ingresses(namespace).List(context.Background(), metav1.ListOptions{})
+		ingresses, err := il.kubeClient.NetworkingV1().Ingresses(namespace).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			il.err = err
 		}
@@ -45,7 +45,7 @@ func (il *List) Populate(namespaces ...string) *List {
 // Filter function applies a filter func that is passed as a parameter to the list of ingresses
 func (il *List) Filter(filterFunc FilterFunc) *List {
 
-	var filtered []v1beta1.Ingress
+	var filtered []v1.Ingress
 
 	for _, ingress := range il.items {
 		if filterFunc(ingress, il.appConfig) {
@@ -59,6 +59,6 @@ func (il *List) Filter(filterFunc FilterFunc) *List {
 }
 
 // Get function returns the ingresses currently present in List
-func (il *List) Get() ([]v1beta1.Ingress, error) {
+func (il *List) Get() ([]v1.Ingress, error) {
 	return il.items, il.err
 }

--- a/internal/kube/wrappers/ingress.go
+++ b/internal/kube/wrappers/ingress.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/toboshii/hajimari/internal/annotations"
 	"github.com/toboshii/hajimari/internal/log"
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/networking/v1"
 )
 
 var (
@@ -15,11 +15,11 @@ var (
 
 // IngressWrapper struct wraps a kubernetes ingress object
 type IngressWrapper struct {
-	ingress *v1beta1.Ingress
+	ingress *v1.Ingress
 }
 
 // NewIngressWrapper func creates an instance of IngressWrapper
-func NewIngressWrapper(ingress *v1beta1.Ingress) *IngressWrapper {
+func NewIngressWrapper(ingress *v1.Ingress) *IngressWrapper {
 	return &IngressWrapper{
 		ingress: ingress,
 	}


### PR DESCRIPTION
This makes hajimari compatible with Kubernetes 1.22. It should be backwards compatible to all Kubernetes versions with Ingress v1 API.

Closes
- #22