### PR TITLE
Add the ability to replace the URL text below the application name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ Hajimari looks for specific annotations on ingresses.
 | Annotation                                   | Description                                                                                                                                                 | Required |
 | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `hajimari.io/enable`             | Add this with value `true` to the ingress of the app you want to show in Hajimari                                                                                       | `true`   |
-| `hajimari.io/icon`               | Icon name from [MDI icons](https://materialdesignicons.com/)                                                                                                           | `false`  |
+| `hajimari.io/icon`               | Icon name from [MDI icons](https://materialdesignicons.com/)                                                                                                            | `false`  |
 | `hajimari.io/appName`            | A custom name for your application. Use if you don't want to use the name of the ingress                                                                                | `false`  |
 | `hajimari.io/group`              | A custom group name. Use if you want the application to show in a different group than the namespace it is running in                                                   | `false`  |
 | `hajimari.io/instance`           | A comma separated list of name/s of the Hajimari instance/s where you want this application to appear. Use when you have multiple Hajimari instances                    | `false`  |
 | `hajimari.io/url`                | A URL for the Hajimari app (This will override the ingress URL). It MUST begin with a scheme i.e., `http://` or `https://`                                              | `false`  |
+| `hajimari.io/info`               | A HTML string to display instead of the URL below the application name (This will take the place of the URL).                                                           | `false`  |
 
 ### Config
 
@@ -95,6 +96,7 @@ If you want to add any apps that are not exposed through ingresses or are extern
 | icon              | URL of the icon for the custom app        | String            |
 | url               | URL of the custom app                     | String            |
 | group             | Group for the custom app                  | String            |
+| info              | Information line for the custom app       | String            |
 
 #### Bookmarks
 

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -13,4 +13,6 @@ const (
 	HajimariInstanceAnnotation = "hajimari.io/instance"
 	// HajimariURLAnnotation const used for specifying the URL for the hajimari app
 	HajimariURLAnnotation = "hajimari.io/url"
+	// HajimariInfoAnnotation const used for specifying the information line
+	HajimariInfoAnnotation = "hajimari.io/info"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type CustomApp struct {
 	Icon  string
 	URL   string
 	Group string
+	Info  string
 }
 
 type Group struct {

--- a/internal/hajimari/customapps/customapps.go
+++ b/internal/hajimari/customapps/customapps.go
@@ -40,12 +40,19 @@ func convertCustomAppsToHajimariApps(customApps []config.CustomApp) (apps []haji
 	for _, customApp := range customApps {
 		logger.Debugf("Found custom app with Name '%v'", customApp.Name)
 
+		var info string
+		if customApp.Info != "" {
+			info = customApp.Info
+		} else {
+			info = customApp.URL
+		}
+
 		apps = append(apps, hajimari.App{
 			Name:  customApp.Name,
 			URL:   customApp.URL,
 			Icon:  customApp.Icon,
 			Group: customApp.Group,
-			Info:  customApp.Info,
+			Info:  customApp.Info == "" ? customApp.URL,
 		})
 	}
 

--- a/internal/hajimari/customapps/customapps.go
+++ b/internal/hajimari/customapps/customapps.go
@@ -45,6 +45,7 @@ func convertCustomAppsToHajimariApps(customApps []config.CustomApp) (apps []haji
 			URL:   customApp.URL,
 			Icon:  customApp.Icon,
 			Group: customApp.Group,
+			Info:  customApp.Info,
 		})
 	}
 

--- a/internal/hajimari/customapps/customapps.go
+++ b/internal/hajimari/customapps/customapps.go
@@ -52,7 +52,7 @@ func convertCustomAppsToHajimariApps(customApps []config.CustomApp) (apps []haji
 			URL:   customApp.URL,
 			Icon:  customApp.Icon,
 			Group: customApp.Group,
-			Info:  info
+			Info:  info,
 		})
 	}
 

--- a/internal/hajimari/customapps/customapps.go
+++ b/internal/hajimari/customapps/customapps.go
@@ -52,7 +52,7 @@ func convertCustomAppsToHajimariApps(customApps []config.CustomApp) (apps []haji
 			URL:   customApp.URL,
 			Icon:  customApp.Icon,
 			Group: customApp.Group,
-			Info:  customApp.Info == "" ? customApp.URL,
+			Info:  info
 		})
 	}
 

--- a/internal/hajimari/hajimari.go
+++ b/internal/hajimari/hajimari.go
@@ -6,4 +6,5 @@ type App struct {
 	Icon  string
 	Group string
 	URL   string
+	Info  string
 }

--- a/internal/hajimari/ingressapps/apps.go
+++ b/internal/hajimari/ingressapps/apps.go
@@ -67,6 +67,7 @@ func convertIngressesToHajimariApps(ingresses []v1.Ingress) (apps []hajimari.App
 			Group: wrapper.GetGroup(),
 			Icon:  wrapper.GetAnnotationValue(annotations.HajimariIconAnnotation),
 			URL:   wrapper.GetURL(),
+			Info:  wrapper.GetInfo(),
 		})
 	}
 	return

--- a/internal/kube/wrappers/ingress.go
+++ b/internal/kube/wrappers/ingress.go
@@ -54,6 +54,14 @@ func (iw *IngressWrapper) GetGroup() string {
 	return iw.GetNamespace()
 }
 
+// GetGroup func extracts group name from the ingress
+func (iw *IngressWrapper) GetInfo() string {
+	if infoFromAnnotation := iw.GetAnnotationValue(annotations.HajimariInfoAnnotation); infoFromAnnotation != "" {
+		return infoFromAnnotation
+	}
+	return iw.GetURL()
+}
+
 // GetURL func extracts url of the ingress wrapped by the object
 func (iw *IngressWrapper) GetURL() string {
 

--- a/web/template/index.html.tmpl
+++ b/web/template/index.html.tmpl
@@ -98,7 +98,7 @@
                         </div>
                         <div class="apps_text">
                             <a href="{{.URL}}">{{.Name}}</a>
-                            <span id="app-address">{{.URL}}</span>
+                            <span id="app-address">{{.Info}}</span>
                         </div>
                     </div>
                 {{end}}


### PR DESCRIPTION
# Overview

Gives the user an option to override the information line using an annotation. This should be a non-breaking change as it will default to displaying the URL like before.

Since this allows you to enter any html you want you can replace the text with a link to a status badge.

`hajimari.io/info: "<img src='https://gatus.local/api/v1/endpoints/downloading_nzbget/uptimes/7d/badge.svg'>"`

![badge](https://user-images.githubusercontent.com/273876/188534518-2761d59e-ee39-4036-9892-e1337134d3b0.PNG)
