### PR TITLE
Add the ability to display a description below the application name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Hajimari looks for specific annotations on ingresses.
 | `hajimari.io/group`              | A custom group name. Use if you want the application to show in a different group than the namespace it is running in                                                   | `false`  |
 | `hajimari.io/instance`           | A comma separated list of name/s of the Hajimari instance/s where you want this application to appear. Use when you have multiple Hajimari instances                    | `false`  |
 | `hajimari.io/url`                | A URL for the Hajimari app (This will override the ingress URL). It MUST begin with a scheme i.e., `http://` or `https://`                                              | `false`  |
+| `hajimari.io/info`               | A short description of the Hajimari app                                                                                | `false`  | 
 
 ### Config
 
@@ -94,6 +95,7 @@ If you want to add any apps that are not exposed through ingresses or are extern
 | name              | Name of the custom app                    | String            |
 | icon              | URL of the icon for the custom app        | String            |
 | url               | URL of the custom app                     | String            |
+| info              | Short description of the custom app       | String            |
 | group             | Group for the custom app                  | String            |
 
 #### Bookmarks

--- a/configv2.yaml
+++ b/configv2.yaml
@@ -11,13 +11,15 @@ lightTheme: gazette
 darkTheme: blackboard
 showGreeting: true
 showAppGroups: false
+showAppInfo: true
 showBookmarkGroups: true
 customApps:
   - group: Media
-    links:
+    apps:
       - name: Test
         url: 'https://example.com'
         icon: test-tube
+        info: This is a test app
       - name: Test2
         url: 'https://example.net'
         icon: test-tube

--- a/frontend/src/lib/AppList/AppGroup.svelte
+++ b/frontend/src/lib/AppList/AppGroup.svelte
@@ -4,6 +4,7 @@
     export let group: any;
     export let defaultIcon: string = 'mdi:application';
     export let showUrl: boolean = true;
+    export let showInfo: boolean = true;
 </script>
 
 
@@ -26,6 +27,9 @@
             <a href="{app.url}">{app.name}</a>
             {#if showUrl === true}
             <span class="app_address">{app.url}</span>
+            {/if}
+            {#if showInfo === true}
+            <span class="app_info">{app.info}</span>
             {/if}
         </div>
     </div>
@@ -78,6 +82,10 @@
     }
 
     .app_address {
+        overflow-wrap: break-word;
+    }
+
+    .app_info {
         overflow-wrap: break-word;
     }
     

--- a/frontend/src/lib/AppList/index.svelte
+++ b/frontend/src/lib/AppList/index.svelte
@@ -5,6 +5,7 @@
     export let showGroups: boolean;
     export let defaultIcon: string = 'mdi:application';
     export let showUrls: boolean = true;
+    export let showInfo: boolean = true;
 </script>
 <div class="apps">
     <h3>Applications</h3>
@@ -17,11 +18,11 @@
                     <div class="links_item">
                         <h4>{group.group}</h4>
                         <div class="apps_group">
-                            <AppGroup {group} showUrl={showUrls} defaultIcon={defaultIcon}/>
+                            <AppGroup {group} showUrl={showUrls} showInfo={showInfo} defaultIcon={defaultIcon}/>
                         </div>
                     </div>
                 {:else}
-                    <AppGroup {group} showUrl={showUrls} defaultIcon={defaultIcon}/>
+                    <AppGroup {group} showUrl={showUrls} showInfo={showInfo} defaultIcon={defaultIcon}/>
                 {/if}
             {/each}
         </div>

--- a/frontend/src/routes/[...slug]/+page.svelte
+++ b/frontend/src/routes/[...slug]/+page.svelte
@@ -15,7 +15,7 @@
 <Greeting name={data.startpage.name} />
 {/if}
 
-<AppList apps={data.apps} showGroups={data.startpage.showAppGroups} showUrls={data.startpage.showAppUrls}/>
+<AppList apps={data.apps} showGroups={data.startpage.showAppGroups} showUrls={data.startpage.showAppUrls} showInfo={data.startpage.showAppInfo}/>
 
 <BookmarkList bookmarks={data.startpage.bookmarks} showGroups={data.startpage.showBookmarkGroups}/>
 

--- a/frontend/src/routes/[...slug]/+page.ts
+++ b/frontend/src/routes/[...slug]/+page.ts
@@ -12,6 +12,7 @@ type Startpage = {
     showGreeting: boolean;
     showAppGroups: boolean;
     showAppUrls: boolean;
+    showAppInfo: boolean;
     showBookmarkGroups: boolean;
     showGlobalBookmarks: boolean;
     bookmarks: any;

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -13,6 +13,8 @@ const (
 	HajimariInstanceAnnotation = "hajimari.io/instance"
 	// HajimariURLAnnotation const used for specifying the URL for the hajimari app
 	HajimariURLAnnotation = "hajimari.io/url"
+	// HajimariInfoAnnotation const used for specifying the info line for the hajimari app
+	HajimariInfoAnnotation = "hajimari.io/info"
 	// HajimariStatusCheckAnnotation boolean used for enabling status indicators.
 	HajimariStatusCheckEnabledAnnotation = "hajimari.io/statusCheckEnabled"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	ShowGreeting        bool                   `default:"true"       json:"showGreeting"`
 	ShowAppGroups       bool                   `default:"false"      json:"showAppGroups"`
 	ShowAppUrls         bool                   `default:"true"       json:"showAppUrls"`
+	ShowAppInfo         bool                   `default:"true"       json:"showAppInfo"`
 	ShowBookmarkGroups  bool                   `default:"true"       json:"showBookmarkGroups"`
 	ShowGlobalBookmarks bool                   `default:"false"      json:"showGlobalBookmarks"`
 	CustomApps          []models.AppGroup      `default:"[]"         json:"customApps"`

--- a/internal/hajimari/ingressapps/apps.go
+++ b/internal/hajimari/ingressapps/apps.go
@@ -89,6 +89,7 @@ func convertIngressesToHajimariApps(ingresses []v1.Ingress, rsg util.ReplicaStat
 					Name: wrapper.GetName(),
 					Icon: wrapper.GetAnnotationValue(annotations.HajimariIconAnnotation),
 					URL:  wrapper.GetURL(),
+					Info: wrapper.GetInfo(),
 					Replicas: models.ReplicaInfo{
 						Total:     replicaStatus.GetReplicas(),
 						Available: replicaStatus.GetAvailableReplicas(),
@@ -100,6 +101,7 @@ func convertIngressesToHajimariApps(ingresses []v1.Ingress, rsg util.ReplicaStat
 					Name: wrapper.GetName(),
 					Icon: wrapper.GetAnnotationValue(annotations.HajimariIconAnnotation),
 					URL:  wrapper.GetURL(),
+					Info: wrapper.GetInfo(),
 				})
 			}
 		}

--- a/internal/kube/wrappers/ingress.go
+++ b/internal/kube/wrappers/ingress.go
@@ -55,6 +55,15 @@ func (iw *IngressWrapper) GetGroup() string {
 	return iw.GetNamespace()
 }
 
+// GetGroup func extracts group name from the ingress
+func (iw *IngressWrapper) GetInfo() string {
+	if infoFromAnnotation := iw.GetAnnotationValue(annotations.HajimariInfoAnnotation); infoFromAnnotation != "" {
+		return infoFromAnnotation
+	}
+	// TODO: Empty instead of listing the URL?
+	return iw.GetURL()
+}
+
 // GetStatusCheckEnabled func extracts statusCheck feature gate from the ingress
 // @default true
 func (iw *IngressWrapper) GetStatusCheckEnabled() bool {

--- a/internal/kube/wrappers/ingress.go
+++ b/internal/kube/wrappers/ingress.go
@@ -60,8 +60,7 @@ func (iw *IngressWrapper) GetInfo() string {
 	if infoFromAnnotation := iw.GetAnnotationValue(annotations.HajimariInfoAnnotation); infoFromAnnotation != "" {
 		return infoFromAnnotation
 	}
-	// TODO: Empty instead of listing the URL?
-	return iw.GetURL()
+	return ""
 }
 
 // GetStatusCheckEnabled func extracts statusCheck feature gate from the ingress

--- a/internal/models/app.go
+++ b/internal/models/app.go
@@ -4,5 +4,6 @@ type App struct {
 	Name     string      `json:"name"`
 	Icon     string      `json:"icon"`
 	URL      string      `json:"url"`
+	Info     string      `json:"info"`
 	Replicas ReplicaInfo `json:"replicas"`
 }

--- a/internal/models/startpage.go
+++ b/internal/models/startpage.go
@@ -10,6 +10,7 @@ type Startpage struct {
 	ShowGreeting        *bool           `json:"showGreeting"`
 	ShowAppGroups       *bool           `json:"showAppGroups"`
 	ShowAppUrls         *bool           `json:"showAppUrls"`
+	ShowAppInfos        *bool           `json:"showAppInfos"`
 	ShowBookmarkGroups  *bool           `json:"showBookmarkGroups"`
 	ShowGlobalBookmarks *bool           `json:"showGlobalBookmarks"`
 	Bookmarks           []BookmarkGroup `json:"bookmarks"`

--- a/internal/models/startpage.go
+++ b/internal/models/startpage.go
@@ -10,7 +10,7 @@ type Startpage struct {
 	ShowGreeting        *bool           `json:"showGreeting"`
 	ShowAppGroups       *bool           `json:"showAppGroups"`
 	ShowAppUrls         *bool           `json:"showAppUrls"`
-	ShowAppInfos        *bool           `json:"showAppInfos"`
+	ShowAppInfo         *bool           `json:"showAppInfo"`
 	ShowBookmarkGroups  *bool           `json:"showBookmarkGroups"`
 	ShowGlobalBookmarks *bool           `json:"showGlobalBookmarks"`
 	Bookmarks           []BookmarkGroup `json:"bookmarks"`

--- a/internal/stores/memory.go
+++ b/internal/stores/memory.go
@@ -15,6 +15,7 @@ var startpages = []*models.Startpage{
 		ShowAppGroups:       pointer.Of(false),
 		ShowGlobalBookmarks: pointer.Of(true),
 		ShowAppUrls:         pointer.Of(true),
+		ShowAppInfo:         pointer.Of(true),
 		Bookmarks: []models.BookmarkGroup{
 			{
 				Group: "Media",


### PR DESCRIPTION
# Overview

Gives the user an option to display a description below the application name using an annotation. 

`hajimari.io/info: "Automated Service Health Dashboard"`

![info-line](https://user-images.githubusercontent.com/273876/189330033-d153641f-0cad-48e0-af37-eb95143161df.PNG)
