### PR TITLE
feat: targetBlank option for apps and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Hajimari looks for specific annotations on ingresses.
 | `hajimari.io/group`              | A custom group name. Use if you want the application to show in a different group than the namespace it is running in                                                   | `false`  |
 | `hajimari.io/instance`           | A comma separated list of name/s of the Hajimari instance/s where you want this application to appear. Use when you have multiple Hajimari instances                    | `false`  |
 | `hajimari.io/url`                | A URL for the Hajimari app (This will override the ingress URL). It MUST begin with a scheme i.e., `http://` or `https://`                                              | `false`  |
+| `hajimari.io/targetBlank`        | Determines if links should open in new tabs/windows                                                                                                                     | `false`  |
 | `hajimari.io/info`               | A short description of the Hajimari app                                                                                | `false`  | 
 
 ### Config

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Hajimari supports the following configuration options that can be modified by ei
 | instanceName      |                                      Name of the Hajimari instance                                         |           ""            | string            |
 | customApps        |                A list of custom apps that you would like to add to the Hajimari instance                   |           {}            | []CustomApp       |
 | groups            |                A list of bookmark groups to add to the Hajimari instance                                   |           {}            | []groups          |
+| targetBlank       |                  Set to true to open apps/bookmarks in a new window by default                     |          false          | bool
 
 #### NamespaceSelector
 
@@ -98,6 +99,7 @@ If you want to add any apps that are not exposed through ingresses or are extern
 | url               | URL of the custom app                     | String            |
 | info              | Short description of the custom app       | String            |
 | group             | Group for the custom app                  | String            |
+| targetBlank       | Open app in a new window                  | Bool              |
 
 #### Bookmarks
 
@@ -106,7 +108,7 @@ Bookmark groups can be added by creating an array of group names and links.
 | Field            | Description                               | Type              |
 | -----------------| ----------------------------------------- | ----------------- |
 | name             | Name of the bookmark group                | String            |
-| links            | Array of links                            | Array             |
+| bookmarks        | Array of bookmarks                        | Array             |
 
 Bookmarks can be added by configuring a list of bookmarks under a group.
 
@@ -114,6 +116,7 @@ Bookmarks can be added by configuring a list of bookmarks under a group.
 | ----------------- | ----------------------------------------- | ----------------- |
 | name              | Name of the bookmark                      | String            |
 | url               | URL of the bookmark                       | String            |
+| targetBlank       | Open link in a new window                 | Bool              |
 
 ### Custom startpage setup
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -11,6 +11,7 @@ showGreeting: true
 showAppGroups: false
 showAppUrls: true
 showAppInfo: false
+targetBlank: false
 showAppStatus: true
 showBookmarkGroups: true
 showGlobalBookmarks: false

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -53,17 +53,19 @@ customApps:
         url: 'https://example.com'
         icon: mdi:test-tube
         info: This is a test app
+        targetBlank: true
 globalBookmarks:
   - group: Communicate
-    links:
+    bookmarks:
       - name: Discord
         url: 'https://discord.com'
       - name: Gmail
         url: 'http://gmail.com'
+        targetBlank: true
       - name: Slack
         url: 'https://slack.com/signin'
   - group: Cloud
-    links:
+    bookmarks:
       - name: Box
         url: 'https://box.com'
       - name: Dropbox
@@ -71,7 +73,7 @@ globalBookmarks:
       - name: Drive
         url: 'https://drive.google.com'
   - group: Design
-    links:
+    bookmarks:
       - name: Awwwards
         url: 'https://awwwards.com'
       - name: Dribbble
@@ -79,7 +81,7 @@ globalBookmarks:
       - name: Muz.li
         url: 'https://medium.muz.li/'
   - group: Dev
-    links:
+    bookmarks:
       - name: Codepen
         url: 'https://codepen.io/'
       - name: Devdocs
@@ -87,7 +89,7 @@ globalBookmarks:
       - name: Devhints
         url: 'https://devhints.io'
   - group: Lifestyle
-    links:
+    bookmarks:
       - name: Design Milk
         url: 'https://design-milk.com/category/interior-design/'
       - name: Dwell
@@ -95,7 +97,7 @@ globalBookmarks:
       - name: Freshome
         url: 'https://www.mymove.com/freshome/'
   - group: Media
-    links:
+    bookmarks:
       - name: Spotify
         url: 'http://browse.spotify.com'
       - name: Trakt
@@ -103,7 +105,7 @@ globalBookmarks:
       - name: YouTube
         url: 'https://youtube.com/feed/subscriptions'
   - group: Reading
-    links:
+    bookmarks:
       - name: Instapaper
         url: 'https://www.instapaper.com/u'
       - name: Medium
@@ -111,7 +113,7 @@ globalBookmarks:
       - name: Reddit
         url: 'http://reddit.com'
   - group: Tech
-    links:
+    bookmarks:
       - name: TheNextWeb
         url: 'https://thenextweb.com/'
       - name: The Verge

--- a/frontend/src/lib/AppList/AppGroup.svelte
+++ b/frontend/src/lib/AppList/AppGroup.svelte
@@ -8,6 +8,7 @@
     export let showUrl: boolean = true;
     export let showInfo: boolean = true;
     export let showStatus: boolean = true;
+    export let targetBlank: boolean = false;
 </script>
 
 {#each group.apps || [] as app (app.name)}
@@ -17,7 +18,7 @@
         animate:flip={{ duration: 300 }}
     >
         <div class="apps_icon">
-            <a href={app.url} target="{app.targetBlank ? "_blank" : "_self"}" rel="noopener noreferrer">
+            <a href={app.url} target="{app.targetBlank == "" ? (targetBlank ? "_blank" : "_self") : (app.targetBlank == "1" ? "_blank" : "_self")}" rel="noopener noreferrer">
                 {#if app.icon.includes("//")}
                     <img src={app.icon} alt="app icon for {app.name}" />
                 {:else if app.icon.includes(":") || !app.icon}
@@ -37,7 +38,7 @@
             {/if}
         </div>
         <div class="apps_text">
-            <a href={app.url} target="{app.targetBlank ? "_blank" : "_self"}" rel="noopener noreferrer">{app.name}</a>
+            <a href={app.url} target="{app.targetBlank == "" ? (targetBlank ? "_blank" : "_self") : (app.targetBlank == "1" ? "_blank" : "_self")}" rel="noopener noreferrer">{app.name}</a>
             {#if showUrl}
                 <span class="app_address">{app.url}</span>
             {/if}

--- a/frontend/src/lib/AppList/AppGroup.svelte
+++ b/frontend/src/lib/AppList/AppGroup.svelte
@@ -16,7 +16,7 @@
         animate:flip={{ duration: 300 }}
     >
         <div class="apps_icon">
-            <a href={app.url}>
+            <a href={app.url} target="{app.targetBlank ? "_blank" : "_self"}">
                 {#if app.icon.includes("//")}
                     <img src={app.icon} alt="app icon for {app.name}" />
                 {:else if app.icon.includes(":") || !app.icon}
@@ -36,7 +36,7 @@
             {/if}
         </div>
         <div class="apps_text">
-            <a href={app.url}>{app.name}</a>
+            <a href={app.url} target="{app.targetBlank ? "_blank" : "_self"}">{app.name}</a>
             {#if showUrl === true}
                 <span class="app_address">{app.url}</span>
             {/if}

--- a/frontend/src/lib/AppList/index.svelte
+++ b/frontend/src/lib/AppList/index.svelte
@@ -8,6 +8,7 @@
     export let showUrl: boolean = true;
     export let showInfo: boolean = true;
     export let showStatus: boolean = true;
+    export let targetBlank: boolean = false;
 </script>
 
 <div class="apps">
@@ -27,6 +28,7 @@
                                 {showInfo}
                                 {showStatus}
                                 {defaultIcon}
+                                {targetBlank}
                             />
                         </div>
                     </div>
@@ -37,6 +39,7 @@
                         {showInfo}
                         {showStatus}
                         {defaultIcon}
+                        {targetBlank}
                     />
                 {/if}
             {/each}

--- a/frontend/src/lib/BookmarkList/BookmarkGroup.svelte
+++ b/frontend/src/lib/BookmarkList/BookmarkGroup.svelte
@@ -5,7 +5,7 @@
 
 <div class="links_item">
     {#each bookmarkGroup.bookmarks as link}
-        <a href={link.url} class="theme_color-border theme_text-select"
+        <a href={link.url} target="{link.targetBlank ? "_blank" : "_self"}" class="theme_color-border theme_text-select"
             >{link.name}</a
         >
     {/each}

--- a/frontend/src/lib/BookmarkList/BookmarkGroup.svelte
+++ b/frontend/src/lib/BookmarkList/BookmarkGroup.svelte
@@ -5,7 +5,7 @@
 
 <div class="links_item">
     {#each bookmarkGroup.bookmarks as link}
-        <a href={link.url} target="{app.targetBlank ? "_blank" : "_self"}" rel="noopener noreferrer"
+        <a href={link.url} target="{link.targetBlank ? "_blank" : "_self"}" rel="noopener noreferrer"
             >{link.name}</a
         >
     {/each}

--- a/frontend/src/lib/BookmarkList/BookmarkGroup.svelte
+++ b/frontend/src/lib/BookmarkList/BookmarkGroup.svelte
@@ -1,11 +1,12 @@
-<script>
+<script type="ts">
     import Icon from "@iconify/svelte";
     export let bookmarkGroup;
+    export let targetBlank: boolean;
 </script>
 
 <div class="links_item">
     {#each bookmarkGroup.bookmarks as link}
-        <a href={link.url} target="{link.targetBlank ? "_blank" : "_self"}" rel="noopener noreferrer"
+        <a href={link.url} target="{link.targetBlank == "" ? (targetBlank ? "_blank" : "_self") : (link.targetBlank == "1" ? "_blank" : "_self")}" rel="noopener noreferrer"
             >{link.name}</a
         >
     {/each}

--- a/frontend/src/lib/BookmarkList/index.svelte
+++ b/frontend/src/lib/BookmarkList/index.svelte
@@ -4,6 +4,7 @@
     export let header: string = "Bookmarks";
     export let bookmarks: [];
     export let showGroups: boolean;
+    export let targetBlank: boolean;
 </script>
 
 {#if bookmarks.length === 0}
@@ -19,10 +20,10 @@
                 {#if showGroups}
                     <div class="links_item">
                         <h4>{bookmarkGroup.group}</h4>
-                        <BookmarkGroup {bookmarkGroup} />
+                        <BookmarkGroup {bookmarkGroup} {targetBlank} />
                     </div>
                 {:else}
-                    <BookmarkGroup {bookmarkGroup} />
+                    <BookmarkGroup {bookmarkGroup} {targetBlank} />
                 {/if}
             {/each}
         </div>

--- a/frontend/src/routes/[...slug]/+page.svelte
+++ b/frontend/src/routes/[...slug]/+page.svelte
@@ -81,11 +81,13 @@
 	showUrl={data.startpage.showAppUrls}
 	showInfo={data.startpage.showAppInfo}
 	showStatus={data.startpage.showAppStatus}
+	targetBlank={data.startpage.targetBlank}
 />
 
 <BookmarkList
 	bookmarks={data.startpage.bookmarks}
 	showGroups={data.startpage.showBookmarkGroups}
+	targetBlank={data.startpage.targetBlank}
 />
 
 {#if data.startpage.showGlobalBookmarks && data.slug !== ""}
@@ -93,6 +95,7 @@
 		header="Global Bookmarks"
 		bookmarks={data.globalBookmarks}
 		showGroups={data.startpage.showBookmarkGroups}
+		targetBlank={data.startpage.targetBlank}
 	/>
 {/if}
 

--- a/frontend/src/routes/[...slug]/+page.ts
+++ b/frontend/src/routes/[...slug]/+page.ts
@@ -14,6 +14,7 @@ type Startpage = {
     showAppGroups: boolean;
     showAppUrls: boolean;
     showAppInfo: boolean;
+    targetBlank: boolean;
     showAppStatus: boolean;
     showBookmarkGroups: boolean;
     showGlobalBookmarks: boolean;

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -17,4 +17,6 @@ const (
 	HajimariInfoAnnotation = "hajimari.io/info"
 	// HajimariStatusCheckAnnotation boolean used for enabling status indicators.
 	HajimariStatusCheckEnabledAnnotation = "hajimari.io/statusCheckEnabled"
+	// HajimariTargetBlankAnnotation boolean used for making links open in a new window.
+	HajimariTargetBlankAnnotation = "hajimari.io/targetBlank"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	ShowAppGroups         bool                    `json:"showAppGroups"`
 	ShowAppUrls           bool                    `json:"showAppUrls"`
 	ShowAppInfo           bool                    `json:"showAppInfo"`
+	TargetBlank           bool                    `json:"targetBlank"`
 	ShowAppStatus         bool                    `json:"showAppStatus"`
 	ShowBookmarkGroups    bool                    `json:"showBookmarkGroups"`
 	ShowGlobalBookmarks   bool                    `json:"showGlobalBookmarks"`
@@ -65,6 +66,7 @@ func SetDefaults() {
 	viper.SetDefault("ShowAppGroups", false)
 	viper.SetDefault("ShowAppUrls", true)
 	viper.SetDefault("ShowAppInfo", false)
+	viper.SetDefault("TargetBlank", false)
 	viper.SetDefault("ShowAppStatus", true)
 	viper.SetDefault("ShowBookmarkGroups", true)
 	viper.SetDefault("ShowGlobalBookmarks", false)

--- a/internal/hajimari/ingressapps/apps.go
+++ b/internal/hajimari/ingressapps/apps.go
@@ -86,10 +86,11 @@ func convertIngressesToHajimariApps(ingresses []v1.Ingress, rsg util.ReplicaStat
 		if i, ok := appMap[wrapper.GetGroup()]; ok {
 			if wrapper.GetStatusCheckEnabled() && (replicaStatus.GetReplicas() != 0) {
 				appGroups[i].Apps = append(appGroups[i].Apps, models.App{
-					Name: wrapper.GetName(),
-					Icon: wrapper.GetAnnotationValue(annotations.HajimariIconAnnotation),
-					URL:  wrapper.GetURL(),
-					Info: wrapper.GetInfo(),
+					Name:        wrapper.GetName(),
+					Icon:        wrapper.GetAnnotationValue(annotations.HajimariIconAnnotation),
+					URL:         wrapper.GetURL(),
+					Info:        wrapper.GetInfo(),
+					TargetBlank: wrapper.GetTargetBlank(),
 					Replicas: models.ReplicaInfo{
 						Total:     replicaStatus.GetReplicas(),
 						Available: replicaStatus.GetAvailableReplicas(),
@@ -98,10 +99,11 @@ func convertIngressesToHajimariApps(ingresses []v1.Ingress, rsg util.ReplicaStat
 				})
 			} else {
 				appGroups[i].Apps = append(appGroups[i].Apps, models.App{
-					Name: wrapper.GetName(),
-					Icon: wrapper.GetAnnotationValue(annotations.HajimariIconAnnotation),
-					URL:  wrapper.GetURL(),
-					Info: wrapper.GetInfo(),
+					Name:        wrapper.GetName(),
+					Icon:        wrapper.GetAnnotationValue(annotations.HajimariIconAnnotation),
+					URL:         wrapper.GetURL(),
+					TargetBlank: wrapper.GetTargetBlank(),
+					Info:        wrapper.GetInfo(),
 				})
 			}
 		}

--- a/internal/kube/wrappers/ingress.go
+++ b/internal/kube/wrappers/ingress.go
@@ -74,11 +74,11 @@ func (iw *IngressWrapper) GetStatusCheckEnabled() bool {
 
 // GetTargetBlank func extracts open in new window feature gate from the ingress
 // @default false
-func (iw *IngressWrapper) GetTargetBlank() bool {
+func (iw *IngressWrapper) GetTargetBlank() string {
 	if targetBlankFromAnnotation := iw.GetAnnotationValue(annotations.HajimariTargetBlankAnnotation); targetBlankFromAnnotation != "" {
-		return utilStrings.ParseBool(targetBlankFromAnnotation)
+		return targetBlankFromAnnotation
 	}
-	return false
+	return ""
 }
 
 // GetURL func extracts url of the ingress wrapped by the object

--- a/internal/kube/wrappers/ingress.go
+++ b/internal/kube/wrappers/ingress.go
@@ -76,7 +76,11 @@ func (iw *IngressWrapper) GetStatusCheckEnabled() bool {
 // @default false
 func (iw *IngressWrapper) GetTargetBlank() string {
 	if targetBlankFromAnnotation := iw.GetAnnotationValue(annotations.HajimariTargetBlankAnnotation); targetBlankFromAnnotation != "" {
-		return targetBlankFromAnnotation
+		if utilStrings.ParseBool(targetBlankFromAnnotation) {
+			return "1"
+		} else {
+			return "0"
+		}
 	}
 	return ""
 }

--- a/internal/kube/wrappers/ingress.go
+++ b/internal/kube/wrappers/ingress.go
@@ -72,6 +72,15 @@ func (iw *IngressWrapper) GetStatusCheckEnabled() bool {
 	return true
 }
 
+// GetTargetBlank func extracts open in new window feature gate from the ingress
+// @default false
+func (iw *IngressWrapper) GetTargetBlank() bool {
+	if targetBlankFromAnnotation := iw.GetAnnotationValue(annotations.HajimariTargetBlankAnnotation); targetBlankFromAnnotation != "" {
+		return utilStrings.ParseBool(targetBlankFromAnnotation)
+	}
+	return false
+}
+
 // GetURL func extracts url of the ingress wrapped by the object
 func (iw *IngressWrapper) GetURL() string {
 

--- a/internal/models/app.go
+++ b/internal/models/app.go
@@ -1,9 +1,10 @@
 package models
 
 type App struct {
-	Name     string      `json:"name"`
-	Icon     string      `json:"icon"`
-	URL      string      `json:"url"`
-	Info     string      `json:"info"`
-	Replicas ReplicaInfo `json:"replicas"`
+	Name        string      `json:"name"`
+	Icon        string      `json:"icon"`
+	URL         string      `json:"url"`
+	Info        string      `json:"info"`
+	TargetBlank bool        `json:"targetBlank"`
+	Replicas    ReplicaInfo `json:"replicas"`
 }

--- a/internal/models/app.go
+++ b/internal/models/app.go
@@ -5,6 +5,6 @@ type App struct {
 	Icon        string      `json:"icon"`
 	URL         string      `json:"url"`
 	Info        string      `json:"info"`
-	TargetBlank bool        `json:"targetBlank"`
+	TargetBlank string      `json:"targetBlank"`
 	Replicas    ReplicaInfo `json:"replicas"`
 }

--- a/internal/models/bookmark.go
+++ b/internal/models/bookmark.go
@@ -4,5 +4,5 @@ type Bookmark struct {
 	Name        string `json:"name"`
 	Icon        string `json:"icon"`
 	URL         string `json:"url"`
-	TargetBlank bool   `json:"targetBlank"`
+	TargetBlank string `json:"targetBlank"`
 }

--- a/internal/models/bookmark.go
+++ b/internal/models/bookmark.go
@@ -1,7 +1,8 @@
 package models
 
 type Bookmark struct {
-	Name string `json:"name"`
-	Icon string `json:"icon"`
-	URL  string `json:"url"`
+	Name        string `json:"name"`
+	Icon        string `json:"icon"`
+	URL         string `json:"url"`
+	TargetBlank bool   `json:"targetBlank"`
 }

--- a/internal/models/startpage.go
+++ b/internal/models/startpage.go
@@ -11,6 +11,7 @@ type Startpage struct {
 	ShowAppGroups         *bool            `json:"showAppGroups"`
 	ShowAppUrls           *bool            `json:"showAppUrls"`
 	ShowAppInfo           *bool            `json:"showAppInfo"`
+	TargetBlank           *bool            `json:"targetBlank"`
 	ShowAppStatus         *bool            `json:"showAppStatus"`
 	ShowBookmarkGroups    *bool            `json:"showBookmarkGroups"`
 	ShowGlobalBookmarks   *bool            `json:"showGlobalBookmarks"`

--- a/internal/stores/memory.go
+++ b/internal/stores/memory.go
@@ -16,6 +16,7 @@ var startpages = []*models.Startpage{
 		ShowGlobalBookmarks: pointer.Of(true),
 		ShowAppUrls:         pointer.Of(true),
 		ShowAppInfo:         pointer.Of(true),
+		TargetBlank:         pointer.Of(false),
 		CustomThemes: []models.Theme{
 			{
 				Name:            "danger",


### PR DESCRIPTION
# Overview

Gives the user an option to have links open in a new tab/window instead of the current window.

| Annotation                                   | Description                                                                                                                                                 | Required |
| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
| `hajimari.io/targetBlank`        | Determines if links should open in new tabs/windows                                                                                                                     | `false`  |

# TODO
* [x] Add a global configuration option that applies to all apps/links