### PR TITLE
fix(frontend): add `rel="external"` to external links

### DIFF
--- a/frontend/src/lib/AppList/AppGroup.svelte
+++ b/frontend/src/lib/AppList/AppGroup.svelte
@@ -18,7 +18,7 @@
         animate:flip={{ duration: 300 }}
     >
         <div class="apps_icon">
-            <a href={app.url} target="{(app.targetBlank || targetBlank) ? '_blank' : null}" rel="noopener noreferrer">
+            <a href={app.url} target="{(app.targetBlank || targetBlank) ? '_blank' : null}" rel="external noopener noreferrer">
                 {#if app.icon.includes("//")}
                     <img src={app.icon} alt="app icon for {app.name}" />
                 {:else if app.icon.includes(":") || !app.icon}
@@ -38,7 +38,7 @@
             {/if}
         </div>
         <div class="apps_text">
-            <a href={app.url} target="{(app.targetBlank || targetBlank) ? '_blank' : null}" rel="noopener noreferrer">{app.name}</a>
+            <a href={app.url} target="{(app.targetBlank || targetBlank) ? '_blank' : null}" rel="external noopener noreferrer">{app.name}</a>
             {#if showUrl}
                 <span class="app_address">{app.url}</span>
             {/if}

--- a/frontend/src/lib/BookmarkList/BookmarkGroup.svelte
+++ b/frontend/src/lib/BookmarkList/BookmarkGroup.svelte
@@ -9,7 +9,7 @@
         <a
             href={link.url}
             target={link.targetBlank || targetBlank ? "_blank" : null}
-            rel="noopener noreferrer"
+            rel="external noopener noreferrer"
         >
             {#if link.icon}
                 {#if link.icon.includes("//")}

--- a/frontend/src/lib/Modal/Modal.svelte
+++ b/frontend/src/lib/Modal/Modal.svelte
@@ -115,7 +115,7 @@
                             ><a
                                 href={provider.url}
                                 target="_blank"
-                                rel="noopener noreferrer"
+                                rel="external noopener noreferrer"
                                 ><Icon icon={provider.icon} inline />
                                 {provider.name}</a
                             ></td
@@ -149,17 +149,17 @@
         <a
             href="https://github.com/toboshii/hajimari"
             target="_blank"
-            rel="noopener noreferrer"><Icon icon="mdi:github-box" /></a
+            rel="external noopener noreferrer"><Icon icon="mdi:github-box" /></a
         >
         <a
             href="https://discord.gg/HWGZSWJsA8"
             target="_blank"
-            rel="noopener noreferrer"><Icon icon="mdi:discord" /></a
+            rel="external noopener noreferrer"><Icon icon="mdi:discord" /></a
         >
         <a
             href="https://icon-sets.iconify.design"
             target="_blank"
-            rel="noopener noreferrer"><Icon icon="mdi:material-design" /></a
+            rel="external noopener noreferrer"><Icon icon="mdi:material-design" /></a
         >
         <button
             on:click={handleSave}

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -34,10 +34,10 @@
             {/if}
 
             <p>
-                If the error persists, please drop by the <a target="_blank" rel="noopener noreferrer" href="https://discord.gg/HWGZSWJsA8">Discord</a
+                If the error persists, please drop by the <a target="_blank" rel="external noopener noreferrer" href="https://discord.gg/HWGZSWJsA8">Discord</a
                 >
                 and let us know, or raise an issue on
-                <a target="_blank" rel="noopener noreferrer" href="https://github.com/toboshii/hajimari/issues/new/choose">GitHub</a>. Thanks!
+                <a target="_blank" rel="external noopener noreferrer" href="https://github.com/toboshii/hajimari/issues/new/choose">GitHub</a>. Thanks!
             </p>
         {/if}
     </section>


### PR DESCRIPTION
This patch resolves the CSRF issue with some apps (most notably, QBitTorrent).
TL;DR: some apps enforce that the `Referer` and `Target` headers must match,
which isn't the case by default with `a` tags, `Referer` is the URL you were
redirected from instead.

This is generally fixed with `rel="noopener noreferrer"` (as implemented by
@toboshii) but SvelteKit's router renders those options useless unless
`rel="external"` is set as well. This effectively bypasses the client-side
router for those links.

Resolves #48.