### PR TITLE
Helm chart config reload

### DIFF
--- a/charts/hajimari/templates/common.yaml
+++ b/charts/hajimari/templates/common.yaml
@@ -10,5 +10,6 @@ volumeSpec:
     name: {{ include "common.names.fullname" . }}-settings
 {{- end -}}
 {{- $_ := set .Values.persistence "hajimari-settings" (include "hajimari.settingsVolume" . | fromYaml) -}}
+{{- $_ := set .Values.controller.annotations "checksum/config" (.Values.hajimari | toYaml | sha256sum) -}}
 
 {{ include "common.all" . }}

--- a/charts/hajimari/templates/common.yaml
+++ b/charts/hajimari/templates/common.yaml
@@ -10,6 +10,6 @@ volumeSpec:
     name: {{ include "common.names.fullname" . }}-settings
 {{- end -}}
 {{- $_ := set .Values.persistence "hajimari-settings" (include "hajimari.settingsVolume" . | fromYaml) -}}
-{{- $_ := set .Values.controller.annotations "checksum/config" (.Values.hajimari | toYaml | sha256sum) -}}
+{{- $_ := set .Values.podAnnotations "checksum/config" (.Values.hajimari | toYaml | sha256sum) -}}
 
 {{ include "common.all" . }}


### PR DESCRIPTION
**Description of the change**

Add a checksum of the configuration as a pod annotation.

**Benefits**

The pods are recreated when the configuration is updated in the helm chart values file.

**Possible drawbacks**

n/a

**Applicable issues**

- fixes #82

**Additional information**

https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
