### PR TITLE
Fix #88 horizontal scrollbar appearing

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -38,7 +38,7 @@ body{
 	margin: 0;
 	padding: 0;
 	webkit-font-smoothing: antialiased;
-	width: 100vw;
+	width: 100%;
 }
 
 *,


### PR DESCRIPTION
**Description of the change**

Changed head & body width from `100vw` to `100%` to get rid of horizontal scrollbar in Chrome.

**Benefits**

No useless horizontal scrollbar appearing

**Possible drawbacks**

Haven't tested in other browsers

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #88 

**Additional information**

Before:
![image](https://user-images.githubusercontent.com/1351924/202410732-133d2c1e-6cfd-4983-a189-cd59104759f1.png)

After:
![image](https://user-images.githubusercontent.com/1351924/202410799-72db1509-da05-43b0-8b97-5a3e49bfb303.png)
