### PR TITLE
feat(kubernetes): add support for Custom Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Hajimari is a simplistically beautiful startpage designed to be the entrypoint f
 ## Features
 
 - Web and app search with customizable search providers
-- Dynamically list apps discovered from Kubernetes ingresses
+- Dynamically list apps discovered from Kubernetes Ingresses or Custom Resources
 - Display replica status for ingress endpoints
 - Support for non-Kubernetes apps via custom apps config
 - Customizable list of bookmarks
@@ -69,7 +69,7 @@ Hajimari will need access to a kubeconfig file for a service account with [acces
 
 ### Ingresses
 
-Hajimari looks for specific annotations on ingresses.
+Hajimari looks for specific annotations on [Ingresses](https://kubernetes.io/docs/concepts/services-networking/ingress/).
 
 - Add the following annotations to your ingresses in order for it to be discovered by Hajimari:
 
@@ -110,6 +110,24 @@ Hajimari supports the following configuration options that can be modified by ei
 |    searchProviders    |                               A list of custom search providers                                | [[...](#default-search-providers)] | \[\][SearchProvider](#searchprovider) |
 |      customApps       |                      A list of custom apps to add to the discovered apps                       |                 []                 | \[\][AppGroup](#appgroup)             |
 |    globalBookmarks    |                                A list of bookmark groups to add                                |                 []                 | \[\][BookmarkGroup](#bookmarkgroup)   |
+
+### HajimariApp objects
+
+It also possible to define Apps via Kubernetes [Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) for those using Istio's [Virtual Services](https://istio.io/latest/docs/reference/config/networking/virtual-service/), Traefik's [IngressRoutes](https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/) or other solutions, which does not reply on native Ingress objects:
+
+```yaml
+apiVersion: hajimari.io/v1alpha1
+kind: Application
+metadata:
+  name: hajimari-issues
+spec:
+  name: Hajimari Issues
+  group: info
+  icon: simple-icons:github
+  url: https://github.com/toboshii/hajimari/issues
+  info: Submit issue to this project
+  targetBlank: true
+```
 
 #### NamespaceSelector
 

--- a/charts/hajimari/templates/app-sample.yaml
+++ b/charts/hajimari/templates/app-sample.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.createCRAppSample }}
+
+apiVersion: hajimari.io/v1alpha1
+kind: Application
+metadata:
+  name: hajimari-issues
+spec:
+  name: Hajimari Issues
+  group: info
+  icon: simple-icons:github
+  url: https://github.com/toboshii/hajimari/issues
+  info: Submit issue to this project
+  targetBlank: true
+
+{{- end }}

--- a/charts/hajimari/templates/crd.yaml
+++ b/charts/hajimari/templates/crd.yaml
@@ -34,7 +34,6 @@ spec:
               required:
                 - name
                 - group
-                - icon
                 - url
               properties:
                 name:

--- a/charts/hajimari/templates/crd.yaml
+++ b/charts/hajimari/templates/crd.yaml
@@ -1,0 +1,53 @@
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.hajimari.io
+spec:
+  conversion:
+    strategy: None
+  group: hajimari.io
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    singular: application
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - name
+                - group
+                - icon
+                - url
+              properties:
+                name:
+                  type: string
+                group:
+                  type: string
+                icon:
+                  type: string
+                url:
+                  type: string
+                info:
+                  type: string
+                targetBlank:
+                  type: boolean
+            status:
+              type: object

--- a/charts/hajimari/templates/rbac.yaml
+++ b/charts/hajimari/templates/rbac.yaml
@@ -4,10 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}
-  labels: {{- include "common.labels" . | nindent 4 }} 
+  labels: {{- include "common.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["", "extensions", "networking.k8s.io", "discovery.k8s.io"]
   resources: ["ingresses", "namespaces", "endpointslices"]
+  verbs: ["get", "list"]
+- apiGroups: ["hajimari.io"]
+  resources: ["applications"]
   verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/hajimari/values.yaml
+++ b/charts/hajimari/values.yaml
@@ -48,7 +48,10 @@ hajimari:
   #       url: 'https://example.com'
   #       icon: 'mdi:test-tube'
   #       info: This is a test app
-  
+
+  # -- Create sample Custom Resource Application
+  createCRAppSample: false
+
   # -- Set default bookmarks
   globalBookmarks: []
   # - group: Communicate

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/go-chi/render v1.0.2
 	github.com/matoous/go-nanoid/v2 v2.0.0
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onrik/logrus v0.9.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/viper v1.13.0
@@ -36,7 +37,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/hajimari/crdapps/apps.go
+++ b/internal/hajimari/crdapps/apps.go
@@ -1,16 +1,16 @@
 package crdapps
 
 import (
+	"github.com/mitchellh/mapstructure"
 	"github.com/toboshii/hajimari/internal/annotations"
 	"github.com/toboshii/hajimari/internal/config"
 	"github.com/toboshii/hajimari/internal/kube/lists/crdapps"
+	"github.com/toboshii/hajimari/internal/kube/types/v1alpha1"
 	"github.com/toboshii/hajimari/internal/kube/wrappers"
 	"github.com/toboshii/hajimari/internal/log"
 	"github.com/toboshii/hajimari/internal/models"
-	"github.com/toboshii/hajimari/internal/kube/types/v1alpha1"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"github.com/mitchellh/mapstructure"
+	"k8s.io/client-go/dynamic"
 )
 
 var (
@@ -19,16 +19,16 @@ var (
 
 // List struct is used for listing hajimari apps
 type List struct {
-	appConfig  config.Config
-	err        error // Used for forwarding errors
-	items      []models.AppGroup
+	appConfig config.Config
+	err       error // Used for forwarding errors
+	items     []models.AppGroup
 	dynClient dynamic.Interface
 }
 
 // NewList func creates a new instance of apps lister
 func NewList(dynClient dynamic.Interface, appConfig config.Config) *List {
 	return &List{
-		appConfig:  appConfig,
+		appConfig: appConfig,
 		dynClient: dynClient,
 	}
 }

--- a/internal/hajimari/crdapps/apps.go
+++ b/internal/hajimari/crdapps/apps.go
@@ -1,0 +1,105 @@
+package crdapps
+
+import (
+	"github.com/toboshii/hajimari/internal/annotations"
+	"github.com/toboshii/hajimari/internal/config"
+	"github.com/toboshii/hajimari/internal/kube/lists/crdapps"
+	"github.com/toboshii/hajimari/internal/kube/wrappers"
+	"github.com/toboshii/hajimari/internal/log"
+	"github.com/toboshii/hajimari/internal/models"
+	"github.com/toboshii/hajimari/internal/kube/types/v1alpha1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/mitchellh/mapstructure"
+)
+
+var (
+	logger = log.New()
+)
+
+// List struct is used for listing hajimari apps
+type List struct {
+	appConfig  config.Config
+	err        error // Used for forwarding errors
+	items      []models.AppGroup
+	dynClient dynamic.Interface
+}
+
+// NewList func creates a new instance of apps lister
+func NewList(dynClient dynamic.Interface, appConfig config.Config) *List {
+	return &List{
+		appConfig:  appConfig,
+		dynClient: dynClient,
+	}
+}
+
+// Populate function that populates a list of hajimari apps from ingresses in selected namespaces
+func (al *List) Populate(namespaces ...string) *List {
+	appsList, err := crdapps.NewList(al.dynClient, al.appConfig).
+		Populate(namespaces...).
+		Get()
+
+	// Apply Instance filter
+	if len(al.appConfig.InstanceName) != 0 {
+		appsList, err = crdapps.NewList(al.dynClient, al.appConfig, appsList...).
+			Get()
+	}
+
+	if err != nil {
+		al.err = err
+	}
+
+	al.items = appsToHajimariApps(appsList)
+
+	return al
+}
+
+// Get function returns the apps currently present in List
+func (al *List) Get() ([]models.AppGroup, error) {
+	return al.items, al.err
+}
+
+func appsToHajimariApps(apps []unstructured.Unstructured) (appGroups []models.AppGroup) {
+	for _, app := range apps {
+		name := app.GetName()
+		namespace := app.GetNamespace()
+
+		logger.Debugf("Found apps with Name '%v' in Namespace '%v'", name, namespace)
+
+		appObj := v1alpha1.Application{}
+		err := mapstructure.Decode(app.UnstructuredContent(), &appObj)
+		if err != nil {
+			logger.Error("Could not unmarshall object: %s/", name, namespace)
+		}
+
+		wrapper := wrappers.NewAppWrapper(&appObj)
+
+		groupMap := make(map[string]int, len(appGroups))
+		for i, v := range appGroups {
+			groupMap[v.Group] = i
+		}
+
+		if _, ok := groupMap[wrapper.GetGroup()]; !ok {
+			appGroups = append(appGroups, models.AppGroup{
+				Group: wrapper.GetGroup(),
+			})
+		}
+
+		appMap := make(map[string]int, len(appGroups))
+		for i, v := range appGroups {
+			appMap[v.Group] = i
+		}
+
+		if i, ok := appMap[wrapper.GetGroup()]; ok {
+			appGroups[i].Apps = append(appGroups[i].Apps, models.App{
+				Name:        wrapper.GetName(),
+				Icon:        wrapper.GetAnnotationValue(annotations.HajimariIconAnnotation),
+				URL:         wrapper.GetURL(),
+				TargetBlank: wrapper.GetTargetBlank(),
+				Info:        wrapper.GetInfo(),
+			})
+		}
+
+	}
+	return
+}

--- a/internal/handlers/apps.go
+++ b/internal/handlers/apps.go
@@ -34,7 +34,7 @@ func (rs *appResource) ListApps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Collect Ingress apps
+	// Collect Kubernetes apps
 
 	cachedKubeApps := rs.service.GetCachedKubeApps()
 

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/toboshii/hajimari/internal/log"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -13,54 +14,44 @@ var (
 	logger = log.New()
 )
 
+func getConfig() *rest.Config {
+	var config *rest.Config
+
+	config, _ = rest.InClusterConfig()
+
+	configPath := os.Getenv("KUBECONFIG")
+	if configPath == "" {
+		configPath = os.Getenv("HOME") + "/.kube/config"
+	}
+	config, _ = clientcmd.BuildConfigFromFlags("", configPath)
+
+	return config
+}
+
 // GetClient returns a k8s clientset
 func GetClient() kubernetes.Interface {
-	var kubeClient kubernetes.Interface
-	_, err := rest.InClusterConfig()
-	if err != nil {
-		kubeClient = getClientOutOfCluster()
-	} else {
-		kubeClient = getClientInCluster()
-	}
+	var client kubernetes.Interface
 
-	return kubeClient
-}
+	config := getConfig()
 
-// GetClientInCluster returns a k8s clientset to the request from inside of cluster
-func getClientInCluster() kubernetes.Interface {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		logger.Fatalf("Can not get kubernetes config: %v", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		logger.Fatalf("Can not create kubernetes client: %v", err)
-	}
-
-	return clientset
-}
-
-func buildOutOfClusterConfig() (*rest.Config, error) {
-	kubeconfigPath := os.Getenv("KUBECONFIG")
-	if kubeconfigPath == "" {
-		kubeconfigPath = os.Getenv("HOME") + "/.kube/config"
-	}
-	return clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-}
-
-// GetClientOutOfCluster returns a k8s clientset to the request from outside of cluster
-func getClientOutOfCluster() kubernetes.Interface {
-	config, err := buildOutOfClusterConfig()
-	if err != nil {
-		logger.Fatalf("Cannot get kubernetes config: %v", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-
+	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		logger.Fatalf("Cannot create new kubernetes client from config: %v", err)
 	}
 
-	return clientset
+	return client
+}
+
+// GetClient returns a k8s clientset
+func GetDynamicClient() dynamic.Interface {
+	var client dynamic.Interface
+
+	config := getConfig()
+
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		logger.Fatalf("Cannot create new kubernetes client from config: %v", err)
+	}
+
+	return client
 }

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -36,7 +36,7 @@ func GetClient() kubernetes.Interface {
 
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		logger.Fatalf("Cannot create new kubernetes client from config: %v", err)
+		logger.Fatalf("Can not create new kubernetes client from config: %v", err)
 	}
 
 	return client
@@ -50,7 +50,7 @@ func GetDynamicClient() dynamic.Interface {
 
 	client, err := dynamic.NewForConfig(config)
 	if err != nil {
-		logger.Fatalf("Cannot create new kubernetes client from config: %v", err)
+		logger.Fatalf("Can not create new kubernetes client from config: %v", err)
 	}
 
 	return client

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -17,7 +17,14 @@ var (
 func getConfig() *rest.Config {
 	var config *rest.Config
 
-	config, _ = rest.InClusterConfig()
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logger.Error("Could not load in-cluster config")
+	}
+
+	if err == nil {
+		return config
+	}
 
 	configPath := os.Getenv("KUBECONFIG")
 	if configPath == "" {

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -4,8 +4,8 @@ import (
 	"os"
 
 	"github.com/toboshii/hajimari/internal/log"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )

--- a/internal/kube/lists/crdapps/crdapps.go
+++ b/internal/kube/lists/crdapps/crdapps.go
@@ -39,7 +39,7 @@ func (il *List) Populate(namespaces ...string) *List {
 		apps, err := il.dynClient.
 			Resource(appResource).
 			Namespace(namespace).
-			List(context.TODO(), metav1.ListOptions{})
+			List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			il.err = err
 		}

--- a/internal/kube/lists/crdapps/crdapps.go
+++ b/internal/kube/lists/crdapps/crdapps.go
@@ -1,0 +1,55 @@
+package crdapps
+
+import (
+	"context"
+
+	"github.com/toboshii/hajimari/internal/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// List struct is used to list ingresses
+type List struct {
+	appConfig  config.Config
+	err        error // Used for forwarding errors
+	items      []unstructured.Unstructured
+	dynClient dynamic.Interface
+}
+
+var appResource = schema.GroupVersionResource{
+	Group: "hajimari.io",
+	Version: "v1alpha1",
+	Resource: "applications",
+}
+
+// NewList creates an List object that you can use to query ingresses
+func NewList(dynClient dynamic.Interface, appConfig config.Config, items ...unstructured.Unstructured) *List {
+	return &List{
+		dynClient:  dynClient,
+		appConfig:  appConfig,
+		items:      items,
+	}
+}
+
+// Populate function returns a list of ingresses
+func (il *List) Populate(namespaces ...string) *List {
+	for _, namespace := range namespaces {
+		apps, err := il.dynClient.
+			Resource(appResource).
+			Namespace(namespace).
+			List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			il.err = err
+		}
+		il.items = append(il.items, apps.Items...)
+	}
+
+	return il
+}
+
+// Get function returns the ingresses currently present in List
+func (il *List) Get() ([]unstructured.Unstructured, error) {
+	return il.items, il.err
+}

--- a/internal/kube/lists/crdapps/crdapps.go
+++ b/internal/kube/lists/crdapps/crdapps.go
@@ -5,31 +5,31 @@ import (
 
 	"github.com/toboshii/hajimari/internal/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 )
 
 // List struct is used to list ingresses
 type List struct {
-	appConfig  config.Config
-	err        error // Used for forwarding errors
-	items      []unstructured.Unstructured
+	appConfig config.Config
+	err       error // Used for forwarding errors
+	items     []unstructured.Unstructured
 	dynClient dynamic.Interface
 }
 
 var appResource = schema.GroupVersionResource{
-	Group: "hajimari.io",
-	Version: "v1alpha1",
+	Group:    "hajimari.io",
+	Version:  "v1alpha1",
 	Resource: "applications",
 }
 
 // NewList creates an List object that you can use to query ingresses
 func NewList(dynClient dynamic.Interface, appConfig config.Config, items ...unstructured.Unstructured) *List {
 	return &List{
-		dynClient:  dynClient,
-		appConfig:  appConfig,
-		items:      items,
+		dynClient: dynClient,
+		appConfig: appConfig,
+		items:     items,
 	}
 }
 

--- a/internal/kube/types/v1alpha1/types.go
+++ b/internal/kube/types/v1alpha1/types.go
@@ -12,12 +12,12 @@ type Application struct {
 }
 
 type ApplicationSpec struct {
-	Name string `json:"name"`
-	Group string `json:"group,omitempty"`
-	Icon string `json:"icon,omitempty"`
-	URL string `json:"url"`
-	Info string `json:"info,omitempty"`
-	TargetBlank bool `json:"targetBlank,omitempty"`
+	Name        string `json:"name"`
+	Group       string `json:"group,omitempty"`
+	Icon        string `json:"icon,omitempty"`
+	URL         string `json:"url"`
+	Info        string `json:"info,omitempty"`
+	TargetBlank bool   `json:"targetBlank,omitempty"`
 }
 
 type ApplicationList struct {

--- a/internal/kube/types/v1alpha1/types.go
+++ b/internal/kube/types/v1alpha1/types.go
@@ -1,0 +1,28 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Application struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ApplicationSpec `json:"spec"`
+}
+
+type ApplicationSpec struct {
+	Name string `json:"name"`
+	Group string `json:"group,omitempty"`
+	Icon string `json:"icon,omitempty"`
+	URL string `json:"url"`
+	Info string `json:"info,omitempty"`
+	TargetBlank bool `json:"targetBlank,omitempty"`
+}
+
+type ApplicationList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+
+	Items []Application `json:"items"`
+}

--- a/internal/kube/util/replicastatusgetter.go
+++ b/internal/kube/util/replicastatusgetter.go
@@ -6,17 +6,17 @@ import (
 	"math"
 
 	// v1 "k8s.io/api/apps/v1"
+	"github.com/toboshii/hajimari/internal/log"
 	networkingV1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes"
-	"github.com/toboshii/hajimari/internal/log"
 )
 
 const (
-	appNameLabelKey		= "app.kubernetes.io/name"
-	serviceNameLabelKey	= "kubernetes.io/service-name"
+	appNameLabelKey     = "app.kubernetes.io/name"
+	serviceNameLabelKey = "kubernetes.io/service-name"
 )
 
 var logger = log.New()
@@ -61,7 +61,7 @@ func (rsg *ReplicaStatusGetter) GetEndpointStatuses(ingress networkingV1.Ingress
 		logger.Debug(ingress.Name, " Multiple EndpointSlices found. Will try using all of them.")
 	}
 
-	if len(epslices.Items)==0 {
+	if len(epslices.Items) == 0 {
 		// This is indication that labels are mismatched somewhere
 		logger.Debug(ingress.Name, " No EndpointSlice Found")
 	}
@@ -124,7 +124,7 @@ func getServiceNames(ingress networkingV1.Ingress) []string {
 	if ingress.Spec.DefaultBackend != nil {
 		serviceNames = append(serviceNames, ingress.Spec.DefaultBackend.Service.Name)
 	}
-	if len(ingress.Spec.Rules)>0 {
+	if len(ingress.Spec.Rules) > 0 {
 		for _, rule := range ingress.Spec.Rules {
 			for _, path := range rule.HTTP.Paths {
 				serviceNames = append(serviceNames, path.Backend.Service.Name)

--- a/internal/kube/wrappers/app.go
+++ b/internal/kube/wrappers/app.go
@@ -1,0 +1,56 @@
+package wrappers
+
+import (
+	// "fmt"
+	// "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/toboshii/hajimari/internal/kube/types/v1alpha1"
+	// "k8s.io/apimachinery/pkg/api/meta"
+)
+
+// AppWrapper struct wraps a kubernetes ingress object
+type AppWrapper struct {
+	app *v1alpha1.Application
+}
+
+// NewAppWrapper func creates an instance of AppWrapper
+func NewAppWrapper(app *v1alpha1.Application) *AppWrapper {
+	return &AppWrapper{
+		app: app,
+	}
+}
+
+// GetName func extracts name of the app wrapped by the object
+func (aw *AppWrapper) GetName() string {
+	return aw.app.Spec.Name
+}
+
+// GetNamespace func extracts namespace of the app wrapped by the object
+func (aw *AppWrapper) GetNamespace() string {
+	return aw.app.ObjectMeta.Namespace
+}
+
+// GetGroup func extracts group name from the app
+func (aw *AppWrapper) GetGroup() string {
+	return aw.app.Spec.Group
+}
+
+// GetGroup func extracts group name from the app
+func (aw *AppWrapper) GetInfo() string {
+	return aw.app.Spec.Info
+}
+
+// GetGroup func extracts group name from the app
+func (aw *AppWrapper) GetAnnotationValue(annotationKey string) string {
+	return aw.app.Spec.Icon
+}
+
+// GetTargetBlank func extracts open in new window feature gate from the app
+// @default false
+func (aw *AppWrapper) GetTargetBlank() bool {
+	return aw.app.Spec.TargetBlank
+}
+
+// GetURL func extracts url of the app wrapped by the object
+func (aw *AppWrapper) GetURL() string {
+	return aw.app.Spec.URL
+}

--- a/internal/kube/wrappers/helpers.go
+++ b/internal/kube/wrappers/helpers.go
@@ -1,0 +1,9 @@
+package wrappers
+
+import (
+	"github.com/toboshii/hajimari/internal/log"
+)
+
+var (
+	logger = log.New()
+)

--- a/internal/kube/wrappers/ingress.go
+++ b/internal/kube/wrappers/ingress.go
@@ -5,13 +5,8 @@ import (
 	"strings"
 
 	"github.com/toboshii/hajimari/internal/annotations"
-	"github.com/toboshii/hajimari/internal/log"
 	utilStrings "github.com/toboshii/hajimari/internal/util/strings"
 	v1 "k8s.io/api/networking/v1"
-)
-
-var (
-	logger = log.New()
 )
 
 // IngressWrapper struct wraps a kubernetes ingress object

--- a/internal/services/app.go
+++ b/internal/services/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/toboshii/hajimari/internal/config"
 	"github.com/toboshii/hajimari/internal/hajimari/ingressapps"
+	"github.com/toboshii/hajimari/internal/hajimari/crdapps"
 	"github.com/toboshii/hajimari/internal/kube"
 	"github.com/toboshii/hajimari/internal/kube/util"
 	"github.com/toboshii/hajimari/internal/log"
@@ -18,11 +19,11 @@ import (
 var (
 	logger          = log.New()
 	mutex           sync.RWMutex
-	ingressAppCache []models.AppGroup
+	kubeAppCache    []models.AppGroup
 )
 
 type AppService interface {
-	GetCachedIngressApps() []models.AppGroup
+	GetCachedKubeApps() []models.AppGroup
 }
 
 type appService struct {
@@ -35,18 +36,17 @@ func NewAppService(logger *logrus.Logger) *appService {
 	updaterChan := make(chan struct{})
 	mutex = sync.RWMutex{}
 
-	ingressAppCache = getIngressApps()
-
-	go startIngressAppCacheUpdater(ticker, updaterChan)
+	kubeAppCache = getKubeApps()
+	go startKubeAppCacheUpdater(ticker, updaterChan)
 
 	return &appService{logger: logger}
 }
 
-func (as *appService) GetCachedIngressApps() []models.AppGroup {
-	return ingressAppCache
+func (as *appService) GetCachedKubeApps() []models.AppGroup {
+	return kubeAppCache
 }
 
-func getIngressApps() []models.AppGroup {
+func getKubeApps() []models.AppGroup {
 	appConfig, err := config.GetConfig()
 	if err != nil {
 		logger.Error("Failed to read configuration for hajimari: ", err)
@@ -54,8 +54,7 @@ func getIngressApps() []models.AppGroup {
 	}
 
 	kubeClient := kube.GetClient()
-
-	ingressAppsList := ingressapps.NewList(kubeClient, *appConfig)
+	dynClient := kube.GetDynamicClient()
 
 	namespaces, err := util.PopulateNamespaceList(kubeClient, appConfig.NamespaceSelector)
 	if err != nil {
@@ -71,25 +70,43 @@ func getIngressApps() []models.AppGroup {
 		namespacesString = strings.Join(namespaces, ", ")
 	}
 
-	logger.Debug("Looking for hajimari apps in the following namespaces: ", namespacesString)
+	logger.Debug("Looking for Hajimari objects in the following namespaces: ", namespacesString)
+
+	// Collect Ingress apps
+
+	ingressAppsList := ingressapps.NewList(kubeClient, *appConfig)
 
 	ingressApps, err := ingressAppsList.Populate(namespaces...).Get()
 	if err != nil {
-		logger.Error("An error occurred while looking for hajimari apps", err)
+		logger.Error("An error occurred while looking for hajimari Ingress apps", err)
 		return nil
 	}
+
+	// Collect Custom Resource apps
+
+	crdAppsList := crdapps.NewList(dynClient, *appConfig)
+
+	crdApps, err := crdAppsList.Populate(namespaces...).Get()
+	if err != nil {
+		logger.Error("An error occurred while looking for hajimari Custom Resource apps", err)
+		return nil
+	}
+
+	// Merge together
+
+	ingressApps = append(ingressApps, crdApps...)
 
 	return ingressApps
 }
 
-func startIngressAppCacheUpdater(ticker *time.Ticker, updaterChan chan struct{}) {
-	logger.Info("IngressApp cache daemon started")
+func startKubeAppCacheUpdater(ticker *time.Ticker, updaterChan chan struct{}) {
+	logger.Info("KubeApp cache daemon started")
 	for {
 		select {
 		case <-ticker.C:
 			// update cache
 			mutex.Lock() // lock the cache before writing to it
-			ingressAppCache = getIngressApps()
+			kubeAppCache = getKubeApps()
 			mutex.Unlock() // unlock the cache after writing to it
 		case <-updaterChan:
 			// stop the daemon

--- a/internal/services/app.go
+++ b/internal/services/app.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/toboshii/hajimari/internal/config"
-	"github.com/toboshii/hajimari/internal/hajimari/ingressapps"
 	"github.com/toboshii/hajimari/internal/hajimari/crdapps"
+	"github.com/toboshii/hajimari/internal/hajimari/ingressapps"
 	"github.com/toboshii/hajimari/internal/kube"
 	"github.com/toboshii/hajimari/internal/kube/util"
 	"github.com/toboshii/hajimari/internal/log"
@@ -17,9 +17,9 @@ import (
 )
 
 var (
-	logger          = log.New()
-	mutex           sync.RWMutex
-	kubeAppCache    []models.AppGroup
+	logger       = log.New()
+	mutex        sync.RWMutex
+	kubeAppCache []models.AppGroup
 )
 
 type AppService interface {


### PR DESCRIPTION
**Description of the change**

This adds support for CRs.

**Benefits**

Now user may use `Application` resource to define items:

```yaml
apiVersion: hajimari.io/v1alpha1
kind: Application
metadata:
  name: hajimari-issues
spec:
  name: Hajimari Issues
  group: info
  icon: simple-icons:github
  url: https://github.com/toboshii/hajimari/issues
  info: Submit issue to this project
  targetBlank: true
```

Which results in:

![Screenshot from 2023-02-08 01-29-38](https://user-images.githubusercontent.com/1294495/217382175-99ac08e2-a0f8-4118-8088-3a02d4f65337.png)

**Possible drawbacks**

I've found none.

**Applicable issues**

- fixes #33 

**Additional information**

I guess, we need to properly bump Helm chart before merging.
